### PR TITLE
removing participant role on challenge submission

### DIFF
--- a/cogs/challenges.py
+++ b/cogs/challenges.py
@@ -25,7 +25,9 @@ class ChallengeHandler(commands.Cog):
         if message.channel.id != 680851820587122700:
             return
 
-        role = self.bot.guild.get_role(687417501931536478)
+        submitted = self.bot.guild.get_role(687417501931536478)
+        participant = self.bot.guild.get_role(687417513918857232)
 
-        if role not in message.author.roles:
-            await message.author.add_roles(role)
+        if submitted not in message.author.roles:
+            await message.author.add_roles(submitted)
+            await message.author.remove_roles(participant)


### PR DESCRIPTION
Since higher up roles can't override permissions lower roles have given, we'll need to remove the participant role on challenge submission. 
As a side note there might need to be some changes made to the role permissions to make sure it works